### PR TITLE
Mostly dependency updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: scala
 jdk:
   - oraclejdk8
-script: "sbt clean coverage test"
+script:
+  - sbt clean coverage test coverageReport
 after_success:
-  - ln -s src/main/scala/com ./
-  - ln -s src/main/scala/kamon ./
   - sbt coveralls
-  - rm -f ./com ./kamon

--- a/build.sbt
+++ b/build.sbt
@@ -12,15 +12,15 @@ description := "Better Kamon metrics for Spray services"
 
 licenses += "BSD" → url("http://opensource.org/licenses/BSD-3-Clause")
 
-scalaVersion := "2.11.7"
+scalaVersion := "2.11.8"
 
 scalacOptions ++= Seq(
   "-deprecation",
   "-unchecked"
 )
 
-val akkaVersion = "2.3.14"
-val kamonVersion = "0.5.2"
+val akkaVersion = "2.4.8"
+val kamonVersion = "0.6.2"
 val sprayVersion = "1.3.3"
 
 libraryDependencies ++= Seq(
@@ -28,8 +28,8 @@ libraryDependencies ++= Seq(
   "io.kamon"           %% "kamon-core"       % kamonVersion,
   "io.spray"           %% "spray-can"        % sprayVersion  % "provided",
   "io.spray"           %% "spray-routing"    % sprayVersion  % "provided",
-  "org.scalatest"      %% "scalatest"        % "2.2.4"       % "test",
-  "ch.qos.logback"      % "logback-classic"  % "1.1.3"       % "test",
+  "org.scalatest"      %% "scalatest"        % "3.0.0"       % "test",
+  "ch.qos.logback"      % "logback-classic"  % "1.1.7"       % "test",
   "com.typesafe.akka"  %% "akka-slf4j"       % akkaVersion   % "test",
   "com.typesafe.akka"  %% "akka-testkit"     % akkaVersion   % "test"
 )
@@ -54,13 +54,9 @@ bintrayPackageLabels := Seq("kamon", "spray", "metrics")
 
 bintrayVcsUrl := Some("https://github.com/MonsantoCo/spray-kamon-metrics")
 
-site.settings
-
 ghpages.settings
 
 git.remoteRepo := "git@github.com:MonsantoCo/spray-kamon-metrics.git"
-
-site.includeScaladoc("api/snapshot")
 
 apiMappingsScala := Map(
   ("com.typesafe.akka", "akka-actor") → "http://doc.akka.io/api/akka/%s"
@@ -72,4 +68,8 @@ apiMappingsJava := Map(
 
 apiURL := Some(url(s"https://monsantoco.github.io/spray-kamon-metrics/api/${(version in ThisBuild).value}"))
 
-site.asciidoctorSupport()
+enablePlugins(AsciidoctorPlugin)
+
+enablePlugins(SiteScaladocPlugin)
+
+siteSubdirName in SiteScaladoc := "api/snapshot"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.8
+sbt.version = 0.13.12

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,11 +1,11 @@
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.1")
+addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.3")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.0.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.2")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.0.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.4")

--- a/release-notes.asciidoc
+++ b/release-notes.asciidoc
@@ -7,7 +7,8 @@ spray-kamon-metrics: release notes
 === 0.1.3-SNAPSHOT
 
 * Dependency updates:
-** Kamon 0.5.2
+** Akka 2.4.8
+** Kamon 0.6.2
 ** Spray 1.3.3
 
 === 0.1.2 (22 Sep 2015)

--- a/src/test/scala/com/monsanto/arch/kamon/spray/can/KamonHttpSpec.scala
+++ b/src/test/scala/com/monsanto/arch/kamon/spray/can/KamonHttpSpec.scala
@@ -48,7 +48,7 @@ class KamonHttpSpec(_system: ActorSystem) extends TestKit(_system) with WordSpec
     // wait for metrics to update
     Thread.sleep(RefreshIntervalMillis * 3)
     val maybeMetrics = Kamon.metrics.find(entity)
-    maybeMetrics shouldBe defined
+    maybeMetrics should be (defined)
     val stats = maybeMetrics.get.asInstanceOf[SprayServerMetrics].stats
 
     stats.uptime.toNanos should be > 0L

--- a/src/test/scala/com/monsanto/arch/kamon/spray/can/server/SprayMonitorSpec.scala
+++ b/src/test/scala/com/monsanto/arch/kamon/spray/can/server/SprayMonitorSpec.scala
@@ -99,7 +99,7 @@ class SprayMonitorSpec(_system: ActorSystem) extends TestKit(_system) with WordS
           monitor ! Identify(1)
           expectMsgType[ActorIdentity]
           val maybeMetrics = Kamon.metrics.find(metricsName, SprayServerMetrics.category)
-          maybeMetrics shouldBe defined
+          maybeMetrics should be (defined)
         }
       }
     }
@@ -133,7 +133,7 @@ class SprayMonitorSpec(_system: ActorSystem) extends TestKit(_system) with WordS
           monitor ! Identify(1)
           expectMsgType[ActorIdentity]
           val maybeMetrics = Kamon.metrics.find(metricsName, SprayServerMetrics.category)
-          maybeMetrics shouldBe defined
+          maybeMetrics should be (defined)
           val typedMetrics = maybeMetrics.get.asInstanceOf[SprayServerMetrics]
           typedMetrics.stats shouldBe stats
         }

--- a/src/test/scala/com/monsanto/arch/kamon/spray/routing/TracingHttpServiceSpec.scala
+++ b/src/test/scala/com/monsanto/arch/kamon/spray/routing/TracingHttpServiceSpec.scala
@@ -53,7 +53,7 @@ class TracingHttpServiceSpec(_system: ActorSystem) extends TestKit(_system) with
         )
 
         val entity = Kamon.metrics.find("spray-service-response-duration", Histogram, tags)
-        entity shouldBe defined
+        entity should be (defined)
         val collectionContext = Kamon.metrics.buildDefaultCollectionContext
         val entitySnapshot = entity.get.collect(collectionContext)
         val snapshot = entitySnapshot.histogram(SingleInstrumentEntityRecorder.Histogram).get


### PR DESCRIPTION
Update plugins, dependencies, Scala, and SBT
- SBT 0.13.8 → 0.13.12
- Scala 2.11.7 → 2.11.8
- Dependencies
  - Akka 2.3.14 → 2.4.8
  - Kamon 0.5.2 → 0.6.2
- Test dependencies
  - logback-classic 1.1.3 → 1.1.7
  - Scalatest 2.2.4 → 3.0.0
- Plugins
  - sbt-release 1.0.1 → 1.0.3
  - sbt-scoverage 1.3.3 → 1.3.5
  - sbt-coveralls 1.0.0 → 1.1.0
  - sbt-site 0.8.2 → 1.0.0
